### PR TITLE
Handle error, pass to callback

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -84,6 +84,7 @@ function cp2local(src, dest, callback) {
 exports = module.exports = client;
 
 exports.scp = function(src, dest, callback) {
+  client.on('error', callback);
   var parsed = client.parse(src);
   if (parsed.host && parsed.path) {
     cp2local(parsed, dest, callback);


### PR DESCRIPTION
This allows the client of scp2 module to handle error accordingly.

Otherwise it breaks:

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: connect ETIMEDOUT
    at errnoException (net.js:901:11)
    at Object.afterConnect [as oncomplete](net.js:892:19)
