### PR TITLE
Fixed the issue with corrupt download when file Size more than ~65K.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -269,7 +269,11 @@ Client.prototype.download = function(src, dest, callback) {
   var self = this;
 
   self.sftp(function(err,sftp){
-    sftp.createReadStream(src).pipe(fs.createWriteStream(dest))
+    var sftp_readStream = sftp.createReadStream(src);
+    sftp_readStream.on('error', function(err){
+      callback(err);
+    });
+    sftp_readStream.pipe(fs.createWriteStream(dest))
     .on('close',function(){
       self.emit('read', src);
       callback(null);


### PR DESCRIPTION
Using stfp.read() we'll have to manually refill the read buffer once the default buffer size of 64*1024 is read. Instead used streams.
