### PR TITLE
fix(client): release underlining resourse

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -97,9 +97,11 @@ Client.prototype.sftp = function(callback) {
 Client.prototype.close = function() {
   if (this.__sftp) {
     this.__sftp.end();
+    this.__sftp = null;
   }
   if (this.__ssh) {
     this.__ssh.end();
+    this.__ssh = null;
   }
 };
 

--- a/lib/scp.js
+++ b/lib/scp.js
@@ -27,8 +27,9 @@ function cp2remote(src, dest, callback) {
       });
     }, function(err) {
       // never forget to close the session
-      client.on('close', function() {
+      client.on('close', function closeHandler() {
         callback(err);
+        client.removeListener('close', closeHandler);
       });
       client.close();
     });
@@ -42,8 +43,9 @@ function cp2remote(src, dest, callback) {
       }
       if (stats.isFile()) {
         client.upload(src, client.remote.path, function(err) {
-          client.on('close', function() {
+          client.on('close', function closeHandler() {
             callback(err);
+            client.removeListener('close', closeHandler);
           });
           client.close();
         });


### PR DESCRIPTION
1. set underlining resource __sftp and __ssh to null after close the client
   otherwise there will be error when I scp with same client second time
2. removeListener after client closed;
   eg: 
   if I want to reuse client muliple times there will be problem
   async.each([folders], function(folder, next) {
   client.scp(folder, dest, function() {
      next();
   })
   }, function done() {

})

in this demo, the next callback will be called twice thus done will be called twice
