### PR TITLE
Fix parallel scp calls stealing sessions

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -87,7 +87,7 @@ function cp2local(client, src, dest, callback) {
 exports = module.exports = global_client;
 
 exports.scp = function(src, dest, callback) {
-  client = new Client();
+  var client = new Client();
   client.on('error', callback);
   var parsed = client.parse(src);
   if (parsed.host && parsed.path) {


### PR DESCRIPTION
Collapse the global client into its own thing. Instantiate a new client with each call and pass that through the function so the global client is not overwritten halfway through if a new client is instantiated.

Thanks to @pskupinski and @crypticswarm for pointing out the parallel client issue and code fix.
