### PR TITLE
Misleading error message "... is not a handle" and strange path

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -223,15 +223,22 @@ Client.prototype.write = function(options, callback) {
 
     sftp.open(destination, 'w', attrs, function(err, handle) {
       if (err) {
-        // destination is directory
+        // destination could be a directory
+        // it eventually can't be accessible
+        // to prevent getting a destination like:
+        // /pubic/app.js/app.js 
+        // we use path.dirname when joining
         destination = path.join(
-          destination, path.basename(options.source)
+          path.dirname(destination), path.basename(options.source)
         );
         destination = unixy(destination);
 
         // for emit write event
         options.destination = destination;
         sftp.open(destination, 'w', attrs, function(err, handle) {
+          if (err)
+            throw new Error('There was an error opening the destination: ' + destination 
+              + '\n' + err + '\n please check the destination file or folder for accessibility');
           _write(handle);
         });
       } else {


### PR DESCRIPTION
I had the problem that on my destination i had a file that was called like a folder on the source directory. So scp failed to access (open) the handle on the destination.

I got a misleading error, it unfortunately took me a few hours to find the cause of this error:
write /home/pi/work/public/scripts/app.js/app.js                // if error then path.join causes this strange path
transfer 1/1 data
Fatal error: handle is not a Buffer