### PR TITLE
Pass arguments to callback

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -83,7 +83,7 @@ function cp2local(client, src, dest, callback) {
   }
   client.download(remote.path, dest, function () {
       client.close();
-      callback();
+      callback.apply(this, arguments);
   });
 }
 


### PR DESCRIPTION
Fixes #30. Sorry @lepture, I've just realised, arguments should be passed to callback.