### PR TITLE
Get filename using path.basename

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -9,8 +9,6 @@ function cp2remote(client, src, dest, callback) {
   client.parse(dest);
 
   var _upload = function(files, callback) {
-    var rootdir = files[0];
-
     async.eachSeries(files, function(fpath, done) {
       fs.stat(fpath, function(err, stats) {
         if (err) {
@@ -18,7 +16,7 @@ function cp2remote(client, src, dest, callback) {
           return;
         }
         if (stats.isFile()) {
-          var fname = path.relative(rootdir, fpath);
+          var fname = path.basename(fpath);
           client.upload(
             fpath, path.join(client.remote.path, fname), done
           );


### PR DESCRIPTION
When globbing for files (e.g. "foo.*") only the first file gets a correct `fname`. The other files get `..` prepended to their `fname`, which causes them to be put in the wrong remote location.

Fixes #27