### PR TITLE
Emit transfer event during download

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -252,7 +252,7 @@ Client.prototype.upload = function(src, dest, callback) {
     },
     function(stat, callback) {
       if (stat.isDirectory()) return callback(new Error('Can not upload a directory'));
-      
+
       // Get the attributes of the source directory
       fs.stat(path.dirname(src), function(err, dirStat) {
         if(err) return callback(err);
@@ -277,6 +277,9 @@ Client.prototype.upload = function(src, dest, callback) {
 
 Client.prototype.download = function(src, dest, callback) {
   var self = this;
+  var transferInterval, transferIntervalId, lastBytes, totalBytes;
+  transferInterval = this._options.transferInterval || 5000;
+  lastBytes = 0;
 
   self.sftp(function(err,sftp){
     if (err) {
@@ -287,12 +290,20 @@ Client.prototype.download = function(src, dest, callback) {
     sftp_readStream.on('error', function(err){
       callback(err);
     });
-    sftp_readStream.pipe(fs.createWriteStream(dest))
+    fsDest = fs.createWriteStream(dest);
+    transferIntervalId = setInterval(function() {
+      totalBytes = fsDest.bytesWritten;
+      lastBytes = totalBytes - lastBytes;
+      self.emit('transfer', fsDest, lastBytes, totalBytes);
+    }, transferInterval);
+    sftp_readStream.pipe(fsDest)
     .on('close',function(){
+      clearInterval(transferIntervalId);
       self.emit('read', src);
       callback(null);
     })
     .on('error', function(err){
+      clearInterval(transferIntervalId);
       callback(err);
     });
   });


### PR DESCRIPTION
## Summary
updated the client download method to emit a transfer event on an interval with the amount transfered thus far.

Example:
```
client = new Scp2.Client config
    client.on 'transfer', (buffer, bytes, totalBytes) ->
      console.log "Total Bytes transfered (#{localFile}): #{totalBytes}"
    client.download remoteFile, localFile, (error) ->
      callback error, localFile
```