### PR TITLE
bump to version 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scp2",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A pure javascript scp program based on ssh2.",
   "author": "Hsiaoming Yang <lepture@me.com>",
   "homepage": "https://github.com/lepture/node-scp2",


### PR DESCRIPTION
This version update needs to be published to npm to use an updated version of ssh2. The current ssh2 version in master is ~0.4.10 where the version published as 0.2.2 in npm has 0.3.6 of ssh2.