### PR TITLE
High level api event listeners

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -91,9 +91,11 @@ exports = module.exports = global_client;
 
 exports.Client = Client;
 
-exports.scp = function(src, dest, callback) {
-  var client = new Client();
-  client.on('error', callback);
+exports.scp = function(client, src, dest, callback) {
+  if (!client) {
+    var client = new Client();
+    client.on('error', callback);
+  }
   var parsed = client.parse(src);
   if (parsed.host && parsed.path) {
     cp2local(client, parsed, dest, callback);

--- a/lib/scp.js
+++ b/lib/scp.js
@@ -91,11 +91,12 @@ exports = module.exports = global_client;
 
 exports.Client = Client;
 
-exports.scp = function(client, src, dest, callback) {
-  if (!client) {
-    var client = new Client();
-    client.on('error', callback);
+exports.scp = function(src, dest, client, callback) {
+  if (typeof client === 'function') {
+    callback = client;
+    client = new Client();
   }
+  client.on('error', callback);
   var parsed = client.parse(src);
   if (parsed.host && parsed.path) {
     cp2local(client, parsed, dest, callback);


### PR DESCRIPTION
when using the high level api scp, you can now pass client. So you can make use of event listeners.