### PR TITLE
Clean dirStat when uploading directories

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -252,11 +252,14 @@ Client.prototype.upload = function(src, dest, callback) {
     },
     function(stat, callback) {
       if (stat.isDirectory()) return callback(new Error('Can not upload a directory'));
-      
+
       // Get the attributes of the source directory
       fs.stat(path.dirname(src), function(err, dirStat) {
         if(err) return callback(err);
-        self.mkdir(path.dirname(dest), dirStat, function(err){ callback(err, stat) });
+
+        var cleanDirStat = {mode: dirStat.mode};
+
+        self.mkdir(path.dirname(dest), cleanDirStat, function(err){ callback(err, stat) });
       });
     },
     function(stat, callback) {


### PR DESCRIPTION
Hi guys!

I ran into a permission problem when copying directories from my OSX laptop to a remote Debian box. The problem seems to be in that the UID/GID of the local OSX user is different than the one of the remote user that doesn't have permission to use it.

This change adds filtering of the `fs.stat()` result so only the file mode is propagated.