### PR TITLE
Emit progress event during file download + delete file on remote server

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,7 @@ var async = require('async');
 var EventEmitter = require('events').EventEmitter;
 var Connection = require('ssh2');
 var _ = require('lodash');
-
+var progressStream = require('progress-stream');
 
 function Client(options) {
   this._options = options || {};
@@ -283,17 +283,30 @@ Client.prototype.download = function(src, dest, callback) {
       return callback(err);
     }
 
-    var sftp_readStream = sftp.createReadStream(src);
-    sftp_readStream.on('error', function(err){
-      callback(err);
-    });
-    sftp_readStream.pipe(fs.createWriteStream(dest))
-    .on('close',function(){
-      self.emit('read', src);
-      callback(null);
-    })
-    .on('error', function(err){
-      callback(err);
+    sftp.stat(src, function (err, stat) {
+      if (err) {
+        return callback(err);
+      }
+      var ps = progressStream({
+        length: stat.size,
+        time: 100
+      });
+      ps.on('progress', function (progress) {
+        self.emit('progress', progress);
+      });
+      var sftp_readStream = sftp.createReadStream(src);
+      sftp_readStream.on('error', function(err){
+        callback(err);
+      });
+      sftp_readStream.pipe(ps).pipe(fs.createWriteStream(dest))
+      .on('close',function(){
+        self.emit('read', src);
+        callback(null);
+      })
+      .on('error', function(err){
+        callback(err);
+      });
+      return self;
     });
   });
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -311,6 +311,18 @@ Client.prototype.download = function(src, dest, callback) {
   });
 };
 
+Client.prototype.unlink = function (filename, callback) {
+  var self = this;
+  self.sftp(function (err, sftp) {
+    if (err) {
+      return callback(err);
+    }
+    sftp.unlink(filename,function(err){
+      return callback(err);
+    })
+  });
+}
+
 exports = module.exports = new Client();
 exports.Client = Client;
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "ssh2"
   ],
   "dependencies": {
-    "ssh2": "~0.4.10",
-    "glob": "~4.0.6",
     "async": "~0.9.0",
-    "lodash": "~2.4.1"
+    "glob": "~4.0.6",
+    "lodash": "~2.4.1",
+    "progress-stream": "^1.2.0",
+    "ssh2": "~0.4.10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi folks,

This adds event to monitor file transfer progress for file download.
Change is based on https://github.com/freeall/progress-stream package

related issues #43 #57

Example:
```javascript
var pretty = require('prettysize');
var prettySeconds = require('pretty-seconds');

client.download(src, dest, callback)
self.client.on('progress', function (progress) {
    console.log(Math.floor(progress.percentage) + ' %');
    console.log(pretty(progress.speed) + '/sec');
    console.log(prettySeconds(progress.eta));
});
```
```
5 %
3.4 MB/sec
1 minute and 35 seconds
```

Also this adds unlink method to delete file on remote server
```javascript
client.unlink(filename, callback) -> callback(err)
```