### PR TITLE
Assign the SSH client to this object immediately

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -58,41 +58,40 @@ Client.prototype.sftp = function(callback) {
   }
 
   var self = this;
-  var ssh = new Connection();
-  ssh.on('connect', function() {
+  this.__ssh = new Connection();
+  this.__ssh.on('connect', function() {
     self.emit('connect');
   });
-  ssh.on('ready', function() {
+  this.__ssh.on('ready', function() {
     self.emit('ready');
 
-    ssh.sftp(function(err, sftp) {
+    self.__ssh.sftp(function(err, sftp) {
       if (err) throw err;
       // save for reuse
       self.__sftp = sftp;
       callback(err, sftp);
     });
   });
-  ssh.on('error', function(err) {
+  this.__ssh.on('error', function(err) {
     self.emit('error', err);
     callback(err);
   });
-  ssh.on('end', function() {
+  this.__ssh.on('end', function() {
     self.emit('end');
   });
-  ssh.on('close', function() {
+  this.__ssh.on('close', function() {
     self.emit('close');
   });
-  ssh.on('keyboard-interactive', function(name, instructions, instructionsLang, prompts, finish) {
+  this.__ssh.on('keyboard-interactive', function(name, instructions, instructionsLang, prompts, finish) {
     self.emit('keyboard-interactive', name, instructions, instructionsLang, prompts, finish);
   });
-  ssh.on('change password', function(message, language, done) {
+  this.__ssh.on('change password', function(message, language, done) {
     self.emit('change password', message, language, done);
   });
-  ssh.on('tcp connection', function(details, accept, reject) {
+  this.__ssh.on('tcp connection', function(details, accept, reject) {
     self.emit('tcp connection', details, accept, reject);
   });
-  ssh.connect(remote);
-  this.__ssh = ssh;
+  this.__ssh.connect(remote);
 };
 Client.prototype.close = function() {
   if (this.__sftp) {


### PR DESCRIPTION
I've been doing some work that catches different connection errors and prompts the user for additional information. This works great except that the SSH client isn't assigned to the Connection object until after the connection. On error, the Connection object doesn't have a references to `this.__ssh` yet, meaning the close method does nothing to cancel out the current request.

This adjust the sftp method so that it assigns the ssh client to `this.__ssh` immediately and uses that as it's reference through the whole method. This has allowed me to properly clean up between connection attempts.
