### PR TITLE
Close the connection when download is complete

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -290,6 +290,7 @@ Client.prototype.download = function(src, dest, callback) {
     sftp_readStream.pipe(fs.createWriteStream(dest))
     .on('close',function(){
       self.emit('read', src);
+      self.close();
       callback(null);
     })
     .on('error', function(err){


### PR DESCRIPTION
``Client.download`` methods although downloading has been finished, sftp connection could not have been close.
So, I decided to close sftp connection, when the download is complete.