### PR TITLE
Checking if connection ended before ready

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,7 @@ function Client(options) {
   this._options = options || {};
 
   this.remote = {};
+  this._isConnectionReady = false;
 }
 util.inherits(Client, EventEmitter);
 
@@ -72,6 +73,8 @@ Client.prototype.sftp = function(callback) {
 
     ssh.sftp(function(err, sftp) {
       if (err) throw err;
+
+      self._isConnectionReady = false;
       // save for reuse
       self.__sftp = sftp;
       callback(err, sftp);
@@ -82,6 +85,11 @@ Client.prototype.sftp = function(callback) {
     callback(err);
   });
   ssh.on('end', function() {
+    if (!self._isConnectionReady = false){
+      var err = 'Connection ended before ready';
+      self.emit('error', err);
+      callback(err);   
+    }
     self.emit('end');
   });
   ssh.on('close', function() {


### PR DESCRIPTION
When using the module against BitVise SSH Server,
In some scenarios the connection was refused but error wasn't sent,
But the connection was ready, and then just suddenly ended.
In that case, the callback under "ready" will be never called and the code is "hanged".
Now, if the connection was ended before being ready, the callback will be called.