### PR TITLE
Solve the loose of the "client object" (avoid the loose of parameters)

### DIFF
--- a/bin/scp2
+++ b/bin/scp2
@@ -174,7 +174,7 @@ function prompt(str, fn) {
 function scp(src, dest, defaults) {
   console.log();
   client.defaults(defaults);
-  client.scp(src, dest, function(err) {
+  client.scp(src, dest, client, function(err) {
     if (err) {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
Avoid recreation of the "client" object if it's already exist (avoid the loose of the defaults parameters for example).