### PR TITLE
Fix parse unit tests and simplify logic

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -25,7 +25,7 @@ Client.prototype.defaults = function(options) {
 Client.prototype.parse = function(remote) {
   if (_.isString(remote)) {
     // username[:password]@host[:port][:/path/to]
-    var regex = /^([a-zA-Z0-9\-\.]+)(?:\:(.*))?@([^:]+)(?:\:([0-9]+))?(?:\:(.*))?$/;
+    var regex = /^([a-zA-Z0-9\-\._]+)(?:\:(.*))?@([^:]+)(?:\:([0-9]+))?(?:\:(.*))?$/;
     var m = remote.match(regex);
     if (!m) return {};
     var ret = {

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,8 +24,8 @@ Client.prototype.defaults = function(options) {
 
 Client.prototype.parse = function(remote) {
   if (_.isString(remote)) {
-    // username:password@host:/path/to
-    var regex = /^([a-zA-Z0-9\-\.]+)(\:.*)?@([^:]+):([^:]+:)?(.*)?$/;
+    // username[:password]@host[:port][:/path/to]
+    var regex = /^([a-zA-Z0-9\-\.]+)(?:\:(.*))?@([^:]+)(?:\:([0-9]+))?(?:\:(.*))?$/;
     var m = remote.match(regex);
     if (!m) return {};
     var ret = {
@@ -33,15 +33,13 @@ Client.prototype.parse = function(remote) {
       host: m[3],
     };
     if (m[2]) {
-      ret.password = m[2].slice(1);
+      ret.password = m[2];
     }
-    if (m.length===6 && m[4]) {
-      ret.port = m[4].slice(0,-1);
+    if (m[4]) {
+      ret.port = m[4];
     }
-    if (m.length===6 && m[5]) {
+    if (m[5]) {
       ret.path = m[5];
-    } else if (m.length===5 && m[4]) {
-      ret.path = m[4];
     }
     this.remote = ret;
     return ret;

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -112,6 +112,15 @@ describe('Client', function() {
     expect(ret.path).to.equal('/home/admin/path');
   });
 
+  it('can handle "_" in username', function() {
+    ret = client.parse('admin_2:bx%9@example.com:12345:/home/admin/path');
+    expect(ret.username).to.equal('admin_2');
+    expect(ret.password).to.equal('bx%9');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+    expect(ret.path).to.equal('/home/admin/path');
+  });
+
 });
 
 describe('when calling from windows', function() {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -19,6 +19,64 @@ describe('Client', function() {
     expect(ret.host).to.equal('example.com');
   });
 
+  //  NOTE: At this time, username is always required
+  // it('can parse host and port', function() {
+  //   ret = client.parse('example.com:12345');
+  //   expect(ret.host).to.equal('example.com');
+  //   expect(ret.port).to.equal('12345');
+  // });
+
+  it('can parse username, host, and port', function() {
+    ret = client.parse('admin@example.com:12345');
+    expect(ret.username).to.equal('admin');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+  });
+
+  it('can parse username, password, host, and port', function() {
+    ret = client.parse('admin:bx%9@example.com:12345');
+    expect(ret.username).to.equal('admin');
+    expect(ret.password).to.equal('bx%9');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+  });
+
+  // NOTE: At this time, username is always required
+  // it('can parse path only', function() {
+  //   ret = client.parse('/home/admin/path');
+  //   expect(ret.path).to.equal('/home/admin/path');
+  // });
+
+  // NOTE: At this time, username is always required
+  // it('can parse host and path', function() {
+  //   ret = client.parse('example.com:/home/admin/path');
+  //   expect(ret.host).to.equal('example.com');
+  //   expect(ret.path).to.equal('/home/admin/path');
+  // });
+
+  // NOTE: At this time, username is always required
+  // it('can parse host, port, and path', function() {
+  //   ret = client.parse('example.com:12345:/home/admin/path');
+  //   expect(ret.host).to.equal('example.com');
+  //   expect(ret.port).to.equal('12345');
+  //   expect(ret.path).to.equal('/home/admin/path');
+  // });
+
+  it('can parse username, host, and path', function() {
+    ret = client.parse('admin@example.com:/home/admin/path');
+    expect(ret.username).to.equal('admin');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.path).to.equal('/home/admin/path');
+  });
+
+  it('can parse username, host, port, and path', function() {
+    ret = client.parse('admin@example.com:12345:/home/admin/path');
+    expect(ret.username).to.equal('admin');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+    expect(ret.path).to.equal('/home/admin/path');
+  });
+
   it('can parse username, password, host, and path', function() {
     ret = client.parse('admin:bx%9@example.com:/home/admin/path');
     expect(ret.username).to.equal('admin');
@@ -27,6 +85,32 @@ describe('Client', function() {
     expect(ret.path).to.equal('/home/admin/path');
   });
 
+  it('can parse username, password, host, port, and path', function() {
+    ret = client.parse('admin:bx%9@example.com:12345:/home/admin/path');
+    expect(ret.username).to.equal('admin');
+    expect(ret.password).to.equal('bx%9');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+    expect(ret.path).to.equal('/home/admin/path');
+  });
+
+  it('can handle "@" in password', function() {
+    ret = client.parse('admin:bx@%9@example.com:12345:/home/admin/path');
+    expect(ret.username).to.equal('admin');
+    expect(ret.password).to.equal('bx@%9');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+    expect(ret.path).to.equal('/home/admin/path');
+  });
+
+  it('can handle ":" in password', function() {
+    ret = client.parse('admin:bx:%9@example.com:12345:/home/admin/path');
+    expect(ret.username).to.equal('admin');
+    expect(ret.password).to.equal('bx:%9');
+    expect(ret.host).to.equal('example.com');
+    expect(ret.port).to.equal('12345');
+    expect(ret.path).to.equal('/home/admin/path');
+  });
 
 });
 


### PR DESCRIPTION
In 6fbafab15151e2b756f358ee7e2283b864b7ae88 the regex for parsing was changed to add support for ':port'. However, the tests were not updated. This fixes the failing tests and simplifies the logic around the parsing.