### PR TITLE
Handle ssh2 errors on connect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -94,7 +94,12 @@ Client.prototype.sftp = function(callback) {
   ssh.on('tcp connection', function(details, accept, reject) {
     self.emit('tcp connection', details, accept, reject);
   });
-  ssh.connect(remote);
+  try {
+    ssh.connect(remote);
+  } catch(e) {
+    e.connectFailed = true;
+    callback(e);
+  }
   this.__ssh = ssh;
 };
 

--- a/lib/scp.js
+++ b/lib/scp.js
@@ -44,6 +44,9 @@ function cp2remote(client, src, dest, callback) {
       }
       if (stats.isFile()) {
         client.upload(src, client.remote.path, function(err) {
+          if (err && err.connectFailed) {
+            return callback(err);
+          }
           client.on('close', function closeHandler() {
             callback(err);
             client.removeListener('close', closeHandler);


### PR DESCRIPTION
ssh throws errors on connect. These errors are not handled with the error callback on the scp2