### PR TITLE
Fix TypeError: argv.unshit is not a function

### DIFF
--- a/bin/scp2
+++ b/bin/scp2
@@ -17,7 +17,7 @@ function main(argv) {
     var args = argv.shift();
     args = args.split('=');
     if (args.length > 1) {
-      argv.unshit(args.slice(1).join('='));
+      argv.unshift(args.slice(1).join('='));
     }
     return args[0];
   };


### PR DESCRIPTION
Fixes typo throwing an error on passing args via CLI:

bin/scp2 -p=51723 foo bar                                                                                                                                                      ⏎
/Users/anton/Code/cloned/node-scp2/bin/scp2:20
      argv.unshit(args.slice(1).join('='));
           ^

TypeError: argv.unshit is not a function
    at getArg (/Users/anton/Code/cloned/node-scp2/bin/scp2:20:12)
    at main (/Users/anton/Code/cloned/node-scp2/bin/scp2:28:11)
    at Object.<anonymous> (/Users/anton/Code/cloned/node-scp2/bin/scp2:7:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:974:3