### PR TITLE
Download of nonexistent files generate file descriptor leak

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -291,19 +291,24 @@ Client.prototype.download = function(src, dest, callback) {
     if (err) {
       return callback(err);
     }
-
-    var sftp_readStream = sftp.createReadStream(src);
-    sftp_readStream.on('error', function(err){
-      callback(err);
-    });
-    sftp_readStream.pipe(fs.createWriteStream(dest))
-    .on('close',function(){
-      self.emit('read', src);
-      self.close();
-      callback(null);
-    })
-    .on('error', function(err){
-      callback(err);
+    sftp.stat(src, function(err, attr) {
+      if (err) {
+        return callback(err);
+      } else {
+        var sftp_readStream = sftp.createReadStream(src);
+        sftp_readStream.on('error', function(err){
+          callback(err);
+        });
+        sftp_readStream.pipe(fs.createWriteStream(dest))
+        .on('close',function(){
+          self.emit('read', src);
+          self.close();
+          callback(null);
+        })
+        .on('error', function(err){
+          callback(err);
+        });
+      }
     });
   });
 };


### PR DESCRIPTION
Protecting the download function when the remote file doesn't exist. This prevents file descriptor leak and creating a empty local file.