### PR TITLE
if no custom client passed set client to global_client to keep defaults

### DIFF
--- a/lib/scp.js
+++ b/lib/scp.js
@@ -94,7 +94,7 @@ exports.Client = Client;
 exports.scp = function(src, dest, client, callback) {
   if (typeof client === 'function') {
     callback = client;
-    client = new Client();
+    client = global_client;
   }
   client.on('error', callback);
   var parsed = client.parse(src);


### PR DESCRIPTION
I was losing my defaults and noticed that a new client is created instead of using the global_client.